### PR TITLE
install launch files in ament_auto_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-install(DIRECTORY
-  launch
-  DESTINATION share/${PROJECT_NAME}/
-)
-
-ament_auto_package()
+ament_auto_package(INSTALL_TO_SHARE launch)


### PR DESCRIPTION
The users of ROS offten install files to share directory and the  `INSTALL_TO_SHARE` argument is available in `ament_auto_package` to install them!